### PR TITLE
Disable shutdown procedure on tomcat server

### DIFF
--- a/tomcat/src/main/tomcat-base/conf/server.xml
+++ b/tomcat/src/main/tomcat-base/conf/server.xml
@@ -17,7 +17,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<Server port="8005" shutdown="SHUTDOWN">
+<Server port="-1">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <!-- The security listener enforce the user to be non root.
        This is not usable yet due to :


### PR DESCRIPTION
In the context of GCP it might be useful to disable the tomcat shutdown procedure as the whole container is usually shutdown instead of the server instance.

Allowing the shutdown procedure is also dangerous as it is protected by a password specified in clear in a configuration file. 

Fix #21 