### PR TITLE
Redirect all logs to the stdout

### DIFF
--- a/tomcat/src/main/tomcat-base/conf/logging.properties
+++ b/tomcat/src/main/tomcat-base/conf/logging.properties
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE
+
+# To see debug messages for HTTP/2 handling, uncomment the following line:
+#org.apache.coyote.http2.level = FINE
+
+# To see debug messages for WebSocket handling, uncomment the following line:
+#org.apache.tomcat.websocket.level = FINE

--- a/tomcat/src/main/tomcat-base/conf/logging.properties
+++ b/tomcat/src/main/tomcat-base/conf/logging.properties
@@ -13,30 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler
 
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+.handlers = java.util.logging.ConsoleHandler
 
 ############################################################
 # Handler specific properties.
 # Describes specific configuration info for Handlers.
 ############################################################
-
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-
-2localhost.org.apache.juli.AsyncFileHandler.level = FINE
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-
-3manager.org.apache.juli.AsyncFileHandler.level = FINE
-3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
 
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
@@ -48,23 +32,10 @@ java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 ############################################################
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers =  java.util.logging.ConsoleHandler
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
-
-# For example, set the org.apache.catalina.util.LifecycleBase logger to log
-# each component that extends LifecycleBase changing state:
-#org.apache.catalina.util.LifecycleBase.level = FINE
-
-# To see debug messages in TldLocationsCache, uncomment the following line:
-#org.apache.jasper.compiler.TldLocationsCache.level = FINE
-
-# To see debug messages for HTTP/2 handling, uncomment the following line:
-#org.apache.coyote.http2.level = FINE
-
-# To see debug messages for WebSocket handling, uncomment the following line:
-#org.apache.tomcat.websocket.level = FINE
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler

--- a/tomcat/src/main/tomcat-base/conf/logging.properties
+++ b/tomcat/src/main/tomcat-base/conf/logging.properties
@@ -1,3 +1,5 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
This PR redirect the application logs and tomcat logs to the console.

The first commit add the default configuration for logging (used as a referential).

Related documentation: https://tomcat.apache.org/tomcat-8.0-doc/logging.html

Fix #27 