### PR TITLE
Run tomcat as a non root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ COPY your-application.war ROOT.war
 # Security best practices
 
 ## Execute tomcat with a non root user
-For security purpose it is recommend to start the tomcat instance using the tomcat user. 
+For security purposes it is recommended to start the Tomcat instance using the `tomcat` user. 
 
-You can do so by adding the following line at the end of your Dockerfile.
+You can do so by adding `USER tomcat` at the end of your Dockerfile.
 
 ```dockerfile
 FROM gcr.io/your-repository/tomcat

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ FROM gcr.io/your-repository/tomcat
 COPY your-application.war ROOT.war
 ```
 
+# Security best practices
+
+## Execute tomcat with a non root user
+For security purpose it is recommend to start the tomcat instance using the tomcat user. 
+
+You can do so by adding the following line at the end of your Dockerfile.
+
+```dockerfile
+FROM gcr.io/your-repository/tomcat
+COPY your-application.war ROOT.war
+
+RUN chown tomcat:tomcat $CATALINA_BASE/webapps/ROOT.war
+USER tomcat
+```
 ## Contributing changes
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/tomcat/src/main/docker/Dockerfile
+++ b/tomcat/src/main/docker/Dockerfile
@@ -13,18 +13,24 @@
 # limitations under the License.
 FROM ${docker.openjdk.image}
 
+RUN groupadd -r tomcat \
+ && useradd -r -g tomcat tomcat
+
 # Environment variable for tomcat
 ENV CATALINA_HOME ${tomcat.home}
 
 # Create Tomcat home
 COPY tomcat-home $CATALINA_HOME
-RUN chmod +x ${CATALINA_HOME}/bin/catalina.sh
+RUN chmod +x ${CATALINA_HOME}/bin/catalina.sh \
+    && chown -R tomcat:tomcat ${CATALINA_HOME}
 
 # Create Tomcat base
 ENV CATALINA_BASE ${tomcat.base}
 COPY tomcat-base $CATALINA_BASE
 RUN mkdir -p $CATALINA_BASE/webapps \
     && mkdir -p $CATALINA_BASE/temp \
+    && chown -R tomcat:tomcat ${CATALINA_BASE} \
+    && chmod -R 400 $CATALINA_BASE/conf
 
 WORKDIR $CATALINA_BASE/webapps
 


### PR DESCRIPTION
This PR allow the user to run the tomcat instance as the tomcat user. 
This behavior provide additional security such as readonly configuration files.

Note:
* Running the server as root is still functional.
* Using the tomcat user require the user to modify their Dockerfile
* The user cannot be change in tomcat Dockefile as the structure test need the default user to be root
* Jsvc mechanism can be considered to change the user at runtime (https://tomcat.apache.org/tomcat-8.5-doc/setup.html)

Fix #19