### PR TITLE
Generate a docker tag if none can be generated from the git revision …

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -31,7 +31,11 @@ else
                 | sed 's/\]//')"
 fi
 
-readonly TAG=$(git rev-parse --short HEAD)
+TAG=$(git rev-parse --short HEAD)
+if [ -z "${TAG}" ]; then
+  TAG="$(date -u +%Y-%m-%d_%H_%M)"
+fi
+
 readonly IMAGE="${PROJECT_NAMESPACE}/tomcat:${TAG}"
 
 echo "Building $IMAGE and running structure tests"


### PR DESCRIPTION
The integration test fail to generate a tag for docker if the .git directory is not present