### PR TITLE
Fix the path to the directory uploaded by cloudbuild

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -20,7 +20,6 @@ readonly projectRoot=$dir/../..
 
 if [ -n "$GCLOUD_FILE" ]; then
   source $dir/gcloud-init.sh
-  cd github/tomcat-runtime
 fi
 
 if [ -n "$DOCKER_NAMESPACE" ]; then
@@ -32,10 +31,9 @@ else
                 | sed 's/\]//')"
 fi
 
-TAG=$(git rev-parse --short HEAD)
-if [ -z "${TAG}" ]; then
-  TAG="$(date -u +%Y-%m-%d_%H_%M)"
-fi
+pushd $projectRoot
+  TAG=$(git rev-parse --short HEAD)
+popd
 
 readonly IMAGE="${PROJECT_NAMESPACE}/tomcat:${TAG}"
 


### PR DESCRIPTION
By changing the current directory, the context uploaded by cloudbuild is not the one expected for the build.
Therefore this PR change the directory to access git metadata and return to the original directory.


