### PR TITLE
Update configuration for integration (service name and health check)

### DIFF
--- a/tests/test-war-integration/src/main/docker/app.yaml
+++ b/tests/test-war-integration/src/main/docker/app.yaml
@@ -1,5 +1,9 @@
 runtime: custom
 env: flex
+service: tomcat-runtime-integration
+
+health_check:
+  enable_health_check: False
 
 manual_scaling:
   instances: 1


### PR DESCRIPTION
During integration tests if multiple applications are tested with the same service name only one application will be uploaded which may biases the tests. Therefore the test application is given an unique service name.

Some tests may also be biases by the load balancer if the health check fail but the load balancer is given an IP, to avoid this issue we can disable the health check.

A similar configuration is present for the Jetty Runtime: https://github.com/GoogleCloudPlatform/jetty-runtime/blob/master/tests/test-war-smoke/src/main/appengine/app.yaml

 