### PR TITLE
Refactor CI and release scripts

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -21,16 +21,6 @@ readonly projectRoot=$dir/../..
 # Load the library with Maven utilities
 source ${projectRoot}/scripts/utils/maven.sh
 
-# If we are in a gcloud environment we want to initialize the gcloud CLI
-if [ -n "$GCLOUD_FILE" ]; then
-  source ${dir}/gcloud-init.sh
-fi
-
-# Generate the Docker image tag from the git tag
-pushd ${projectRoot}
-  export DOCKER_TAG_LONG=$(git rev-parse --short HEAD)
-popd
-
 # If no namespace is specified deduct it from the gcloud CLI
 if [ -z "$DOCKER_NAMESPACE" ]; then
   export DOCKER_NAMESPACE="gcr.io/$(gcloud info \
@@ -39,7 +29,16 @@ if [ -z "$DOCKER_NAMESPACE" ]; then
                 | sed 's/\]//')"
 fi
 
-readonly IMAGE=$(maven_utils::get_property cloudbuild.tomcat.image)
+# If we are in a gcloud environment we want to initialize the gcloud CLI
+if [ -n "$GCLOUD_FILE" ]; then
+  source ${dir}/gcloud-init.sh
+fi
+
+# Generate the Docker image tag from the git tag and generate the complete image name
+pushd ${projectRoot}
+  export DOCKER_TAG_LONG=$(git rev-parse --short HEAD)
+  readonly IMAGE=$(maven_utils::get_property cloudbuild.tomcat.image)
+popd
 
 echo "Building $IMAGE and running structure tests"
 ${projectRoot}/scripts/build.sh

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -20,13 +20,11 @@ readonly projectRoot=$dir/../..
 
 # Load the library with Maven utilities
 source ${projectRoot}/scripts/utils/maven.sh
+source ${projectRoot}/scripts/utils/gcloud.sh
 
 # If no namespace is specified deduct it from the gcloud CLI
 if [ -z "$DOCKER_NAMESPACE" ]; then
-  export DOCKER_NAMESPACE="gcr.io/$(gcloud info \
-                | awk '/^Project: / { print $2 }' \
-                | sed 's/\[//'  \
-                | sed 's/\]//')"
+  export DOCKER_NAMESPACE="gcr.io/$(gcloud_utils::get_project_name)"
 fi
 
 # If we are in a gcloud environment we want to initialize the gcloud CLI

--- a/scripts/ci/release-cloudbuild.yaml
+++ b/scripts/ci/release-cloudbuild.yaml
@@ -1,0 +1,21 @@
+steps:
+# Perform maven build, omitting local docker operations
+- name: 'gcr.io/cloud-builders/java/mvn:3.5.0-jdk-8'
+  args:
+    - '--batch-mode'
+    - '-P-local-docker-build'
+    - '-P-test.local'
+    - '-Ddocker.tag.long=${_DOCKER_TAG}'
+    - 'clean'
+    - 'install'
+
+# Build the runtime container
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=${_IMAGE}', '--no-cache', 'tomcat/target/docker-src']
+
+# Runtimes-common structure tests
+# See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
+- name: 'gcr.io/gcp-runtimes/structure_test'
+  args: ['--image', '${_IMAGE}', '-v', '--config', '/workspace/tomcat/target/test-classes/structure.yaml']
+
+images: ['${_IMAGE}']

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dir=$(dirname $0)
+projectRoot=${dir}/../..
+RUNTIME_NAME='tomcat'
+RUNTIME_VERSION='8.5'
+
+if [ -z "${DOCKER_TAG}" ]; then
+  DOCKER_TAG="${RUNTIME_VERSION}-$(date -u +%Y-%m-%d_%H_%M)"
+fi
+
+if [ -z "$DOCKER_NAMESPACE" ]; then
+  DOCKER_NAMESPACE="gcr.io/$(gcloud info \
+                | awk '/^Project: / { print $2 }' \
+                | sed 's/\[//'  \
+                | sed 's/\]//')"
+fi
+
+IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG}"
+
+gcloud container builds submit \
+        --config ${dir}/release-cloudbuild.yaml \
+        --substitutions="_IMAGE=$IMAGE,_DOCKER_TAG=$DOCKER_TAG" \
+        ${projectRoot}

--- a/scripts/utils/gcloud.sh
+++ b/scripts/utils/gcloud.sh
@@ -14,25 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dir=$(dirname $0)
-projectRoot=${dir}/../..
-
-source ${projectRoot}/scripts/utils/gcloud.sh
-
-RUNTIME_NAME='tomcat'
-RUNTIME_VERSION='8.5'
-
-if [ -z "${DOCKER_TAG}" ]; then
-  DOCKER_TAG="${RUNTIME_VERSION}-$(date -u +%Y-%m-%d_%H_%M)"
-fi
-
-if [ -z "$DOCKER_NAMESPACE" ]; then
-  DOCKER_NAMESPACE="gcr.io/$(gcloud_utils::get_project_name)"
-fi
-
-IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG}"
-
-gcloud container builds submit \
-        --config ${dir}/release-cloudbuild.yaml \
-        --substitutions="_IMAGE=$IMAGE,_DOCKER_TAG=$DOCKER_TAG" \
-        ${projectRoot}
+function gcloud_utils::get_project_name () {
+  echo $(gcloud info \
+                | awk '/^Project: / { print $2 }' \
+                | sed 's/\[//'  \
+                | sed 's/\]//')
+}


### PR DESCRIPTION
The release is now handled by a separate script in order to transition to a build entirely handled by cloudbuild (ci/release.sh).

The maven commands during integration test is now executed in the project root directory (ci/script.sh) 