### PR TITLE
Use BASH_SOURCE array to determine build script location

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@
 # All the arguments passed to this script are transferred to the maven command
 #
 
-dir=$(dirname $0)
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 projectRoot=${dir}/..
 
 source ${projectRoot}/scripts/utils/maven.sh


### PR DESCRIPTION
see also https://github.com/GoogleCloudPlatform/jetty-runtime/pull/192 and https://github.com/GoogleCloudPlatform/openjdk-runtime/pull/113