### PR TITLE
Move the distributed session configuration into the main context

### DIFF
--- a/tomcat/src/main/tomcat-base/conf/server.xml
+++ b/tomcat/src/main/tomcat-base/conf/server.xml
@@ -57,7 +57,11 @@
 
         &gcp-configuration;
 
-        &distributed-session-configuration;
+        <Context path="/">
+
+          &distributed-session-configuration;
+
+        </Context>
 
       </Host>
     </Engine>


### PR DESCRIPTION
The configuration for the distributed sessions module (the `Manager` and the `Valve`) must be placed into a `Context` instead of the `Host` component.