### PR TITLE
Use a global handler for logging in the integration test

### DIFF
--- a/tests/test-war-integration/src/main/resources/logging.properties
+++ b/tests/test-war-integration/src/main/resources/logging.properties
@@ -1,5 +1,6 @@
 com.google.cloud.runtimes.level = FINE
 # Ideally we would prefer to set the handler for a specific class however this is not functional yet.
+# com.google.cloud.runtimes.tomcat.test.handlers = com.google.cloud.logging.LoggingHandler
 handlers = com.google.cloud.logging.LoggingHandler
 
 com.google.cloud.logging.LoggingHandler.level = FINE

--- a/tests/test-war-integration/src/main/resources/logging.properties
+++ b/tests/test-war-integration/src/main/resources/logging.properties
@@ -1,4 +1,5 @@
 com.google.cloud.runtimes.level = FINE
+# Ideally we would prefer to set the handler for a specific class however this is not functional yet.
 handlers = com.google.cloud.logging.LoggingHandler
 
 com.google.cloud.logging.LoggingHandler.level = FINE

--- a/tests/test-war-integration/src/main/resources/logging.properties
+++ b/tests/test-war-integration/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 com.google.cloud.runtimes.level = FINE
-com.google.cloud.runtimes.handlers = com.google.cloud.logging.LoggingHandler
+handlers = com.google.cloud.logging.LoggingHandler
 
 com.google.cloud.logging.LoggingHandler.level = FINE
 com.google.cloud.logging.LoggingHandler.log = appengine.googleapis.com%2Fstdout


### PR DESCRIPTION
The handler set for `com.google.cloud.runtimes` in `logging.properties` is ignored by the application. This cause the integration tests relative to logging to fail.

This usage is documented at [Google Cloud Logging](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-logging#add-a-stackdriver-logging-handler-to-a-logger) but doesn't seems to work. 

This PR set the handler for the application instead of a class.