### PR TITLE
Increase the CloudBuild timeout to 25 minutes 

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -50,4 +50,5 @@ echo "Running integration tests on application that is deployed at $DEPLOYED_APP
 gcloud container builds submit \
   --config $testAppDir/target/cloudbuild/integration.yaml \
   --substitutions "_DEPLOYED_APP_URL=$DEPLOYED_APP_URL" \
+  --timeout=25m \
   ${dir}


### PR DESCRIPTION
Fix #81 