### PR TITLE
Improve checkstyle configuration 

### DIFF
--- a/checkstyle/custom-checks.xml
+++ b/checkstyle/custom-checks.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="RegexpHeader">
+    <property name="fileExtensions" value="java"/>
+    <property name="headerFile" value="${checkstyle.header.file}"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="UnusedImports"/>
+  </module>
+</module>

--- a/checkstyle/java.header
+++ b/checkstyle/java.header
@@ -1,0 +1,15 @@
+^/\*$
+^ \* Copyright \(C\) \d\d\d\d Google Inc\.$
+^ \*$
+^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+^ \* you may not use this file except in compliance with the License\.$
+^ \* You may obtain a copy of the License at$
+^ \*$
+^ \*     http://www.apache.org/licenses/LICENSE-2.0$
+^ \*$
+^ \* Unless required by applicable law or agreed to in writing, software$
+^ \* distributed under the License is distributed on an "AS IS" BASIS,$
+^ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+^ \* See the License for the specific language governing permissions and$
+^ \* limitations under the License\.$
+^ \*/$

--- a/tomcat-gcp-lib/pom.xml
+++ b/tomcat-gcp-lib/pom.xml
@@ -118,12 +118,46 @@
               <configLocation>google_checks.xml</configLocation>
             </configuration>
           </execution>
+          <execution>
+            <id>validate-file-header</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <headerLocation>../checkstyle/java.header</headerLocation>
+              <configLocation>../checkstyle/custom-checks.xml</configLocation>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.20</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8.2</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.0.21</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Add check for unused imports, licenses and compile using javac-errorprone.

Fix #65 