### PR TITLE
Define session expiration time base on the context properties (Distributed sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ The distributed sessions module can be configured through the environment variab
 |---|---|---|
 | gcp.distributed-sessions.namespace    |  Namespace to use in the Datastore.                         |  tomcat-gcp-persistent-session |
 | gcp.distributed-sessions.sessionKind  |  Name of the entity used to store sessions in the Datastore. |  TomcatGCloudSession |
-| gcp.distributed-sessions.sessionMaxInactiveTime |  Defines the maximum time (in seconds) a session can be inactive before being deleted by the expiration process. | 3600 |
 | gcp.distributed-sessions.uriExcludePattern | [Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) specifying which URI to ignore when persisting sessions. | null |
 
 For example on Google App Engine:
@@ -85,7 +84,7 @@ For example on Google App Engine:
 ```yaml
 env_variables:
   TOMCAT_MODULES_ENABLE: distributed-sessions
-  TOMCAT_PROPERTIES: gcp.distributed-sessions.sessionMaxInactiveTime=2000,gcp.distributed-sessions.uriExcludePattern=^/_ah/.*
+  TOMCAT_PROPERTIES: gcp.distributed-sessions.uriExcludePattern=^/_ah/.*
 ```
 
 #### Usage outside of Google Cloud Platform

--- a/tests/test-distributed-war/src/main/java/com/google/cloud/runtimes/tomcat/test/distributed/SessionServlet.java
+++ b/tests/test-distributed-war/src/main/java/com/google/cloud/runtimes/tomcat/test/distributed/SessionServlet.java
@@ -37,6 +37,8 @@ public class SessionServlet extends HttpServlet {
 
     int count = 0;
     Object sessionValue = req.getSession().getAttribute("count");
+    resp.getWriter().println("Max inactive time: " + req.getSession().getMaxInactiveInterval());
+
     if (sessionValue != null) {
       count = (int)sessionValue;
       count++;

--- a/tests/test-distributed-war/src/main/webapp/WEB-INF/web.xml
+++ b/tests/test-distributed-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		        http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+    version="3.1">
+  <display-name>Web Application for Servlet 3.1</display-name>
+  <session-config>
+    <session-timeout>1</session-timeout>
+  </session-config>
+</web-app>

--- a/tomcat/src/main/resources/config/distributed-sessions.xml
+++ b/tomcat/src/main/resources/config/distributed-sessions.xml
@@ -3,6 +3,5 @@
 <Manager className="com.google.cloud.runtimes.tomcat.session.DatastoreManager" >
   <Store className="com.google.cloud.runtimes.tomcat.session.DatastoreStore"
          namespace="${gcp.distributed-sessions.namespace}"
-         sessionKind="${gcp.distributed-sessions.sessionKind}"
-         sessionMaxInactiveTime="${gcp.distributed-sessions.sessionMaxInactiveTime}" />
+         sessionKind="${gcp.distributed-sessions.sessionKind}" />
 </Manager>

--- a/tomcat/src/main/tomcat-base/conf/catalina.properties
+++ b/tomcat/src/main/tomcat-base/conf/catalina.properties
@@ -155,8 +155,5 @@ gae.proxy.trusted=".*"
 gcp.distributed-sessions.namespace=tomcat-gcp-persistent-session
 gcp.distributed-sessions.sessionKind=TomcatGCloudSession
 
-# Defines the maximum time (in seconds) a session can be inactive before being deleted by the expiration process.
-gcp.distributed-sessions.sessionMaxInactiveTime=3600
-
 # Specify which Uri to ignore when persisting sessions.
 gcp.distributed-sessions.uriExcludePattern=


### PR DESCRIPTION
The attribute `gcp.distributed-sessions.sessionMaxInactiveTime` is removed and instead the expiration interval for the sessions are deduced from the context or the sessions properties.

It can be set for example in web.xml:
``` xml
<session-config>
     <session-timeout>1</session-timeout>
</session-config>
```
Or on individual session:
`session..setMaxInactiveInterval(1000)`

Fix #82 